### PR TITLE
Add compatibility with Hogfather-Update

### DIFF
--- a/action/mediaattachment.php
+++ b/action/mediaattachment.php
@@ -19,7 +19,7 @@ class action_plugin_mediaattachment_mediaattachment extends DokuWiki_Action_Plug
 
     private $privatens = null;
 
-    public function register(Doku_Event_Handler &$controller) {
+    public function register(Doku_Event_Handler $controller) {
         $this->privatens = cleanID(trim($this->getConf('privatens')));
         $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this, 'handle_tpl_metaheader_output');
         $controller->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handle_ajax');
@@ -127,6 +127,7 @@ class action_plugin_mediaattachment_mediaattachment extends DokuWiki_Action_Plug
             'type' => 'text/javascript',
             'charset' => 'utf-8',
             'src' => $url,
+            'defer' => true
         );
     }
 


### PR DESCRIPTION
Since the Hogfather-Update, the signature of the register() method was changed. This update is required to use the plugin with Dokuwiki >= Hogfather.

https://www.dokuwiki.org/devel:action_plugins#register_method

Additionally JavaScripts that use jQuery need to be loaded deferred:
https://www.dokuwiki.org/devel:javascript?s%5B%5D=deferred#deferred_loading